### PR TITLE
fix: Python 3.9 호환성 지원

### DIFF
--- a/.claude/hooks/session_stop.py
+++ b/.claude/hooks/session_stop.py
@@ -15,6 +15,7 @@ import re
 import os
 from pathlib import Path
 from datetime import datetime
+from typing import Union
 
 # 경로 설정
 HOME_DIR = os.environ.get('HOME', '')
@@ -34,7 +35,7 @@ MEMORY_PATH = PROJECT_MEMORY if PROJECT_MEMORY.exists() else GLOBAL_MEMORY
 MEMORY_PATH_WRITE = PROJECT_MEMORY
 
 
-def load_json(path: Path) -> dict | list:
+def load_json(path: Path) -> Union[dict, list]:
     """JSON 파일 로드"""
     if not path.exists():
         return {}
@@ -45,7 +46,7 @@ def load_json(path: Path) -> dict | list:
         return {}
 
 
-def save_json(path: Path, data: dict | list):
+def save_json(path: Path, data: Union[dict, list]):
     """JSON 파일 저장"""
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, 'w', encoding='utf-8') as f:

--- a/.claude/hooks/track_changes.py
+++ b/.claude/hooks/track_changes.py
@@ -14,6 +14,7 @@ import sys
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 
 def get_project_root() -> Path:
@@ -28,7 +29,7 @@ PROJECT_ROOT = get_project_root()
 STATE_DIR = PROJECT_ROOT / '.claude-state'
 
 
-def load_json(path: Path) -> list | dict:
+def load_json(path: Path) -> Union[list, dict]:
     """JSON 파일 로드"""
     if not path.exists():
         return []
@@ -39,7 +40,7 @@ def load_json(path: Path) -> list | dict:
         return []
 
 
-def save_json(path: Path, data: list | dict):
+def save_json(path: Path, data: Union[list, dict]):
     """JSON 파일 저장"""
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, 'w', encoding='utf-8') as f:

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -15,6 +15,7 @@ import re
 import os
 from pathlib import Path
 from datetime import datetime
+from typing import Optional
 
 # 경로 설정
 HOME_DIR = os.environ.get('HOME', '')
@@ -52,7 +53,7 @@ def save_json(path: Path, data: dict):
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def detect_slash_command(prompt: str) -> dict | None:
+def detect_slash_command(prompt: str) -> Optional[dict]:
     """슬래시 명령어 감지"""
     prompt_stripped = prompt.strip()
 
@@ -130,7 +131,7 @@ def detect_slash_command(prompt: str) -> dict | None:
     return None
 
 
-def detect_work_intent(prompt: str) -> dict | None:
+def detect_work_intent(prompt: str) -> Optional[dict]:
     """프롬프트에서 작업 의도 감지 (슬래시 명령어 + 자연어 키워드)"""
 
     # 1. 슬래시 명령어 우선 감지
@@ -385,7 +386,7 @@ def create_default_context_file(context_file: Path):
         pass
 
 
-def log_user_prompt(prompt: str, intent: dict | None):
+def log_user_prompt(prompt: str, intent: Optional[dict]):
     """사용자 프롬프트 로깅 (슬래시 명령어 + 자연어 모두 기록)"""
     log_file = STATE_PATH / 'prompt_history.json'
 
@@ -514,7 +515,7 @@ def update_work_history(prompt: str, intent: dict):
         pass
 
 
-def get_context_reminder(intent: dict | None) -> str:
+def get_context_reminder(intent: Optional[dict]) -> str:
     """작업 의도 기반 컨텍스트 리마인더"""
     if not intent:
         return ""

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Claude 런타임 상태 (자동 생성됨)
 .claude-state/
 
+# Python 캐시
+__pycache__/
+*.pyc
+
 # 생성된 문서 (PRD, 아키텍처, 태스크)
 docs/
 .claude/project-context


### PR DESCRIPTION
## Summary
  - `dict | list` → `Union[dict, list]` 변경 (Python 3.10+ 전용 문법)
  - `dict | None` → `Optional[dict]` 변경
  - Python 3.9 이하 환경에서 훅 실행 시 TypeError 해결

  ## Changed Files
  - `.claude/hooks/session_stop.py`
  - `.claude/hooks/track_changes.py`
  - `.claude/hooks/user_prompt_submit.py`

  ## Test
  - 전체 11개 훅 파일 문법 검증 통과
  - 수정된 3개 파일 실행 테스트 통과